### PR TITLE
fix(search): prevent fetching data twice

### DIFF
--- a/src/datatable.js
+++ b/src/datatable.js
@@ -46,6 +46,10 @@ export class DataTable {
     this.load();
   }
 
+  detached() {
+    this.ready = false;
+  }
+
   pageChanged() {
     this.load();
   }

--- a/src/datatable.js
+++ b/src/datatable.js
@@ -107,6 +107,10 @@ export class DataTable {
   doSearch() {
     this.criteria.where = {[this.searchColumn]: {contains: this.search}};
 
+    if (!this.pager) {
+      return;
+    }
+
     this.pager.reloadCount();
 
     this.load();

--- a/src/datatable.js
+++ b/src/datatable.js
@@ -41,6 +41,8 @@ export class DataTable {
   }
 
   attached() {
+    this.ready = true;
+
     this.load();
   }
 
@@ -107,7 +109,7 @@ export class DataTable {
   doSearch() {
     this.criteria.where = {[this.searchColumn]: {contains: this.search}};
 
-    if (!this.pager) {
+    if (!this.ready) {
       return;
     }
 


### PR DESCRIPTION
When setting the `search-column` the first time it will fetch the data based on the same empty criteria.
Because this is called before `attached`, pager is not yet defined resulting in a error. (renders in view)
- Fixes requesting the same data twice.
- Fixes calculating and fetching the total amount of items twice on the same criteria.
