### PR TITLE
fix(datatable): fix viewing template in IE edge

### DIFF
--- a/src/bootstrap/datatable.html
+++ b/src/bootstrap/datatable.html
@@ -55,7 +55,7 @@
         <td colspan.bind="colspan" innerhtml.bind="loadingIndicator"></td>
       </tr>
 
-      <template containerless repeat.for="row of data" if.bind="!loading">
+      <template containerless repeat.for="row of data">
         <tr>
           <td style="text-align: center;" if.bind="detailView" click.delegate="collapseRow(row)"><i class="fa fa-${row._collapsed ? 'chevron-down' : 'chevron-right'}"></i></td>
 

--- a/src/bootstrap/datatable.html
+++ b/src/bootstrap/datatable.html
@@ -56,7 +56,7 @@
       </tr>
 
       <template containerless repeat.for="row of data">
-        <tr>
+        <tr if.bind="!loading">
           <td style="text-align: center;" if.bind="detailView" click.delegate="collapseRow(row)"><i class="fa fa-${row._collapsed ? 'chevron-down' : 'chevron-right'}"></i></td>
 
           <!-- Columns -->


### PR DESCRIPTION
IE edge doesn't like `report.for` and `if.bind` on the same element. The `if.bind` was not needed.

Without this fix IE edge won't display any rows.

Bug: https://github.com/aurelia/templating/issues/542