### PR TITLE
Fix: Datatable row action buttons for IE

### DIFF
--- a/src/bootstrap/datatable.html
+++ b/src/bootstrap/datatable.html
@@ -75,7 +75,7 @@
               <i class="fa fa-trash"></i>
             </button>
 
-            <button repeat.for="action of actions" if.bind="checkVisibility(action, row)" t="[title]${action.title}" title.bind="action.title || ''" disabled.bind="checkDisabled(action, row)" class="btn btn-sm btn-${action.type || 'default'}" click.trigger="doCustomAction(action, row, $parent.$index)">
+            <button repeat.for="action of actions" show.bind="checkVisibility(action, row)" t="[title]${action.title}" title.bind="action.title || ''" disabled.bind="checkDisabled(action, row)" class="btn btn-sm btn-${action.type || 'default'}" click.trigger="doCustomAction(action, row, $parent.$index)">
               <i if.bind="action.icon" class="fa fa-${action.icon}"></i>
               <span if.bind="!action.icon && action.title" t="${action.title}">${action.title}</span>
             </button>


### PR DESCRIPTION
This fix allows the action buttons to be displayed on IE
![screenshot from 2018-01-25 09-35-14](https://user-images.githubusercontent.com/5903760/35378449-1d3759f4-01b3-11e8-99df-d737dc04606d.png)
